### PR TITLE
 Fix error where bitcoin address received contains an error

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -65,10 +65,6 @@ async fn main() -> std::io::Result<()> {
 
     let send_amount = (client.get_balance().unwrap().to_sat()) as f64 * 0.5;
 
-    dbg!(&client.get_balance().unwrap().to_sat());
-    dbg!(&send_amount);
-    dbg!(&client.get_balance().unwrap().to_sat());
-
     client
         .send_amount(COLD_WALLET_ADDRESS.get().unwrap(), send_amount as u64)
         .await


### PR DESCRIPTION
 Fix error where bitcoin address received contains an error
 
 This commit ensures an error is returned rather than panicking whenever
 parsing a bitcoin address is invalid.
 
 This commit also trims a bitcoin address
